### PR TITLE
show alert to browsers that can't handle optional chaining.

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,14 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WMG3PNX"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
+    <script>
+      try {
+        const obj={test: 1};
+        const allowChainingTest = obj?.test;
+      } catch (e) {
+        alert('Your browser is not supported. Please update your browser to the latest version.');
+      }
+    </script>
     <noscript>
       <strong>We're sorry but QuestLists doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>


### PR DESCRIPTION
Fixes #132